### PR TITLE
ci: add manual trigger, update readme from code.json

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
+  workflow_dispatch:
 jobs:
   executables-intel:
     name: pymake CI intel on different OSs
@@ -46,9 +47,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install wheel
           pip install https://github.com/modflowpy/pymake/zipball/master
-
-      - name: Print Python package versions
-        run: |
           pip list
 
       - name: build executables on Linux and macOS
@@ -78,7 +76,6 @@ jobs:
             ./code.json
             ./code.md
 
-
   # make the release if previous job was successful
   release:
     name: Make a release
@@ -101,28 +98,28 @@ jobs:
           releases-only: true  # We know that all relevant tags have a GitHub release for them.
         id: executables  # The step ID to refer to later.
 
-      - name: Set latest release tag as a environment variable
+      - name: Get latest release tag
         run: |
           current="${{ steps.executables.outputs.tag }}"
           # next="${current%.*}.$((${current##*.}+1))"
           next=$(echo "${{ steps.executables.outputs.tag }} + 1.0" | bc)
           echo "RELEASE_VERSION=$current" >> $GITHUB_ENV
           echo "NEXT_VERSION=$next" >> $GITHUB_ENV
-          echo "MODFLOW-USGS/executables current version is $current"
-          echo "MODFLOW-USGS/executables next version is $next"
+          
+          repo="${{ github.repository }}"
+          echo "$repo current version is $current"
+          echo "$repo next version is $next"
 
-      - name: Download a Build Artifact
+      - name: Download release artifact
         uses: actions/download-artifact@v3.0.0
         with:
           name: release_build
           path: ./release_build/
 
-      - name: List files in the artifact directory
-        run: |
-          pwd
-          ls -l ./release_build/
+      - name: List artifact files
+        run: ls -l ./release_build/
 
-      - name: Create the Header for BodyFile markdown file
+      - name: Create release body header
         shell: python
         run: |
           import os
@@ -133,18 +130,48 @@ jobs:
           with open('Header.md', "w") as file:
               file.write(line)
 
-      - name: Build of BodyFile.md
+      - name: Build release body
         run: |
           cat Header.md
-
-      - name: List contents of BodyFile.md
-        run: |
           cat Header.md ./release_build/code.md > BodyFile.md
           cat BodyFile.md
           rm ./release_build/code.md
 
-      - name: Create a Release
-        if: github.event_name == 'push'
+      - name: Make code.json
+        run: |
+          make-code-json -f code.json --verbose
+          cat code.json
+
+      - name: Update readme
+        run: |
+          python update_readme.py
+          cat README.md
+
+      - name: Draft pull request
+        # only open PR on manual trigger
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          # commit and push
+          branch="update-readme-${{ env.NEXT_VERSION }}"
+          git config core.sharedRepository true
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git switch -c $branch
+          git commit -m "ci(release): update readme"
+          git push -u origin "$branch"
+          
+          # create PR
+          body='
+          # MODFLOW executables release '${{ env.NEXT_VERSION }}'
+          
+          This PR updates `README.md` with the latest release information.
+          '
+          gh pr create -B "master" -H "$branch" --title "Release ${{ env.NEXT_VERSION }}" --draft --body "$body"
+
+      - name: Create release
+        # only create new release on manual trigger
+        if: github.event_name == 'workflow_dispatch'
         uses: ncipollo/release-action@v1.11.2
         with:
           tag: ${{ env.NEXT_VERSION }}

--- a/update_readme.py
+++ b/update_readme.py
@@ -41,6 +41,6 @@ def _clean_files() -> None:
 
 
 if __name__ == "__main__":
-    _create_code_json()
+    # _create_code_json()
     _update_readme()
     _clean_files()


### PR DESCRIPTION
- Add a trigger on `workflow_dispatch` to allow triggering releases from the GitHub UI or CLI, e.g. from the project root:
```
gh workflow run continuous_integration.yml
```
- Add CI step to automatically update `README.md` from `code.json`
- Add CI step to open a draft PR with `README.md` updates, but only on manually triggered runs. The step to publish a release is also skipped on `push`, only to be run on manual trigger &mdash; this allows updating `master` without making a new release
- Minimal refactoring